### PR TITLE
Display labels from .sposx files

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -236,8 +236,10 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
             this, SLOT(scoreInteractionModeChanged(ScoreWidget::InteractionMode)));
     connect(m_scoreWidget, SIGNAL(interactionEnded(ScoreWidget::InteractionMode)),
             this, SLOT(scoreInteractionEnded(ScoreWidget::InteractionMode)));
-    connect(m_scoreWidget, SIGNAL(selectionChanged(int, bool, int, bool)),
-            this, SLOT(scoreSelectionChanged(int, bool, int, bool)));
+    connect(m_scoreWidget,
+            SIGNAL(selectionChanged(int, bool, QString, int, bool, QString)),
+            this,
+            SLOT(scoreSelectionChanged(int, bool, QString, int, bool, QString)));
     connect(m_scoreWidget, SIGNAL(pageChanged(int)),
             this, SLOT(scorePageChanged(int)));
 
@@ -2463,21 +2465,26 @@ MainWindow::highlightFrameInScore(sv_frame_t frame)
 }
 
 void
-MainWindow::scoreSelectionChanged(int start, bool atStart,
-                                  int end, bool atEnd)
+MainWindow::scoreSelectionChanged(int start, bool atStart, QString startLabel,
+                                  int end, bool atEnd, QString endLabel)
 {
     SVDEBUG << "MainWindow::scoreSelectionChanged: start = " << start
-            << ", atStart = " << atStart << ", end = " << end
-            << ", atEnd = " << atEnd << endl;
+            << ", atStart = " << atStart << ", startLabel = " << startLabel
+            << ", end = " << end << ", atEnd = " << atEnd << ", endLabel = "
+            << endLabel << endl;
 
     if (atStart) {
         m_selectFrom->setText(tr("Start"));
+    } else if (startLabel != "") {
+        m_selectFrom->setText(startLabel);
     } else {
         m_selectFrom->setText(QString("%1").arg(start));
     }
 
     if (atEnd) {
         m_selectTo->setText(tr("End"));
+    } else if (endLabel != "") {
+        m_selectTo->setText(endLabel);
     } else {
         m_selectTo->setText(QString("%1").arg(end));
     }

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -306,6 +306,11 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
         }
     });
 
+    m_resetSelectionButton = new QPushButton(tr("Reset"));
+    connect(m_resetSelectionButton, SIGNAL(clicked()),
+            m_scoreWidget, SLOT(clearSelection()));
+    m_resetSelectionButton->setEnabled(false);
+    
     selectionLayout->addWidget(new QLabel(" "), 0, 0);
     selectionLayout->addWidget(selectFromLabel, 0, 1, Qt::AlignRight);
     selectionLayout->addWidget(selectFromButton, 0, 2);
@@ -313,6 +318,7 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
     selectionLayout->addWidget(selectToLabel, 1, 1, Qt::AlignRight);
     selectionLayout->addWidget(selectToButton, 1, 2);
     selectionLayout->addWidget(m_selectTo, 1, 3);
+    selectionLayout->addWidget(m_resetSelectionButton, 1, 4);
     selectionLayout->setColumnStretch(3, 10);
 
     selectionGroupBox->setLayout(selectionLayout);
@@ -2272,7 +2278,7 @@ MainWindow::chooseScore() // Added by YJ Oct 5, 2021
 {
     m_scorePageDownButton->setEnabled(false);
     m_scorePageUpButton->setEnabled(false);
-    
+
     auto scores = ScoreFinder::getScoreNames();
     std::set<std::string> byName;
     for (auto s: scores) {
@@ -2512,6 +2518,7 @@ MainWindow::scoreSelectionChanged(int start, bool atStart,
     }
 
     m_subsetOfScoreSelected = (!atStart || !atEnd);
+    m_resetSelectionButton->setEnabled(m_subsetOfScoreSelected);
     updateAlignButtonText();
 }
 

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -212,6 +212,7 @@ protected:
     QLabel                  *m_scorePageLabel;
     QLabel                  *m_selectFrom;
     QLabel                  *m_selectTo;
+    QPushButton             *m_resetSelectionButton;
 
     bool                     m_mainMenusCreated;
     QMenu                   *m_paneMenu;

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -138,7 +138,8 @@ protected slots:
     void scorePositionActivated(int, ScoreWidget::InteractionMode);
     void actOnScorePosition(int, ScoreWidget::InteractionMode, bool activated);
     void scoreInteractionEnded(ScoreWidget::InteractionMode);
-    void frameIlluminated(sv_frame_t);
+    void alignmentAccepted();
+    void alignmentFrameIlluminated(sv_frame_t);
     void highlightFrameInScore(sv_frame_t);
     void scoreSelectionChanged(int, bool, int, bool);
     void scorePageChanged(int page);
@@ -162,8 +163,6 @@ protected slots:
     void layerRemoved(Layer *) override;
     void layerInAView(Layer *, bool) override;
 
-    void onsetsLayerCompleted();
-    
     void mainModelChanged(ModelId) override;
     virtual void mainModelGainChanged(float);
     virtual void mainModelPanChanged(float);

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -352,9 +352,6 @@ protected:
 
     bool m_subsetOfScoreSelected;
     void updateAlignButtonText();
-    
-    bool isOnsetsLayer(Layer *) const;
-    TimeValueLayer *findOnsetsLayer(Pane ** = nullptr) const;
 };
 
 

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -141,7 +141,7 @@ protected slots:
     void alignmentAccepted();
     void alignmentFrameIlluminated(sv_frame_t);
     void highlightFrameInScore(sv_frame_t);
-    void scoreSelectionChanged(int, bool, int, bool);
+    void scoreSelectionChanged(int, bool, QString, int, bool, QString);
     void scorePageChanged(int page);
     void scorePageDownButtonClicked();
     void scorePageUpButtonClicked();

--- a/main/ScoreElement.h
+++ b/main/ScoreElement.h
@@ -16,6 +16,8 @@
 #include <vector>
 #include <map>
 
+#include <QString>
+
 struct ScoreElement {
     int id;
     double x;
@@ -23,6 +25,7 @@ struct ScoreElement {
     double sy;
     int page;
     int position;
+    QString label;
     
     ScoreElement() : id(0), x(0.0), y(0.0), sy(0.0), page(0), position(0) { }
 };

--- a/main/ScorePositionReader.h
+++ b/main/ScorePositionReader.h
@@ -31,10 +31,9 @@ public:
     }
     
 private:
-    QString m_scoreName;
     QString m_scoreFilename;
 
-    bool loadScoreFile(QString filename);
+    bool loadScoreFile(QString filename, bool isExtendedFormat);
 	
     ScoreElements m_elements;
 };

--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -75,7 +75,10 @@ ScoreWidget::loadAScore(QString scoreName)
     if (!loadAScore(scoreName, errorString)) {
         emit loadFailed(scoreName, tr("Failed to load score %1: %2")
                         .arg(scoreName).arg(errorString));
+        return;
     }
+
+    clearSelection();
 }
 
 bool
@@ -231,6 +234,26 @@ ScoreWidget::mousePressEvent(QMouseEvent *e)
 #endif
         emit scorePositionActivated(m_mousePosition, m_mode);
     }
+}
+
+void
+ScoreWidget::clearSelection()
+{
+#ifdef DEBUG_SCORE_WIDGET
+    SVDEBUG << "ScoreWidget::clearSelection" << endl;
+#endif
+
+    if (m_selectStartPosition == -1 && m_selectEndPosition == -1) {
+        return;
+    }
+
+    m_selectStartPosition = -1;
+    m_selectEndPosition = -1;
+
+    emit selectionChanged(m_selectStartPosition, true,
+                          m_selectEndPosition, true);
+
+    update();
 }
 
 int

--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -224,8 +224,12 @@ ScoreWidget::mousePressEvent(QMouseEvent *e)
         int end = m_selectEndPosition;
         if (start == -1) start = getStartPosition();
         if (end == -1) end = getEndPosition();
-        emit selectionChanged(start, isSelectedFromStart(),
-                              end, isSelectedToEnd());
+        emit selectionChanged(start,
+                              isSelectedFromStart(),
+                              labelForPosition(start),
+                              end,
+                              isSelectedToEnd(),
+                              labelForPosition(end));
     }
     
     if (m_mousePosition >= 0) {
@@ -250,8 +254,12 @@ ScoreWidget::clearSelection()
     m_selectStartPosition = -1;
     m_selectEndPosition = -1;
 
-    emit selectionChanged(m_selectStartPosition, true,
-                          m_selectEndPosition, true);
+    emit selectionChanged(m_selectStartPosition,
+                          true,
+                          labelForPosition(getStartPosition()),
+                          m_selectEndPosition,
+                          true,
+                          labelForPosition(getEndPosition()));
 
     update();
 }
@@ -348,10 +356,26 @@ ScoreWidget::rectForPosition(int pos)
     SVDEBUG << "ScoreWidget::rectForPosition: Position "
             << pos << " has corresponding element id="
             << elt.id << " on page=" << elt.page << " with x="
-            << elt.x << ", y=" << elt.y << ", sy=" << elt.sy << endl;
+            << elt.x << ", y=" << elt.y << ", sy=" << elt.sy
+            << ", label= " << elt.label << endl;
 #endif
 
     return rectForElement(elt);
+}
+    
+QString
+ScoreWidget::labelForPosition(int pos)
+{
+    auto itr = m_elementsByPosition.lower_bound(pos);
+    if (itr == m_elementsByPosition.end()) {
+#ifdef DEBUG_SCORE_WIDGET
+        SVDEBUG << "ScoreWidget::rectForPosition: Position " << pos
+                << " does not have any corresponding element" << endl;
+#endif
+        return {};
+    }
+
+    return itr->second.label;
 }
 
 QRectF

--- a/main/ScoreWidget.h
+++ b/main/ScoreWidget.h
@@ -120,10 +120,16 @@ signals:
      * toEndOfScore flags are set if the start and/or end correspond
      * to the very start/end of the whole score, in which case the UI
      * may prefer to show the value using terms like "start" or "end"
-     * rather than positional values.
+     * rather than positional values. The labels contain any label
+     * found associated with the element at the given score position,
+     * but may be empty.
      */
-    void selectionChanged(int startPosition, bool toStartOfScore,
-                          int endPosition, bool toEndOfScore);
+    void selectionChanged(int startPosition,
+                          bool toStartOfScore,
+                          QString startLabel,
+                          int endPosition,
+                          bool toEndOfScore,
+                          QString endLabel);
     
     void pageChanged(int page);
 
@@ -161,6 +167,7 @@ private:
     QRectF rectForPosition(int pos);
     QRectF rectForElement(const ScoreElement &elt);
     int positionForPoint(QPoint point);
+    QString labelForPosition(int pos);
     
     ScoreElements m_elements;
     typedef std::multimap<int, ScoreElement> PositionElementMap;

--- a/main/ScoreWidget.h
+++ b/main/ScoreWidget.h
@@ -100,6 +100,13 @@ public slots:
      */
     void setInteractionMode(InteractionMode mode);
 
+    /**
+     * Clear the selection back to the default (everything
+     * selected). If a selection was present, also emit
+     * selectionChanged.
+     */
+    void clearSelection();
+
 signals:
     void loadFailed(QString scoreName, QString errorMessage);
     void interactionModeChanged(ScoreWidget::InteractionMode newMode);

--- a/main/Session.h
+++ b/main/Session.h
@@ -20,7 +20,7 @@
 #include "layer/SpectrogramLayer.h"
 #include "layer/TimeValueLayer.h"
 
-#include "view/View.h"
+#include "view/Pane.h"
 
 #include "data/model/Model.h"
 
@@ -33,8 +33,8 @@ public:
     virtual ~Session();
 
     void setDocument(Document *,
-                     View *topView,
-                     View *bottomView,
+                     Pane *topPane,
+                     Pane *bottomPane,
                      Layer *timeRuler);
 
     void unsetDocument();
@@ -48,18 +48,24 @@ public:
                                sv_frame_t audioFrameStart,
                                sv_frame_t audioFrameEnd);
 
+    TimeValueLayer *getOnsetsLayer();
+    Pane *getPaneContainingOnsetsLayer();
+    
+    TimeValueLayer *getTempoLayer();
+    Pane *getPaneContainingTempoLayer();
+                                                        
 protected slots:
     void modelReady(ModelId);
     
 private:
     // I don't own any of these. The SV main window owns the document
-    // and views; the document owns the layers and models
+    // and panes; the document owns the layers and models
     Document *m_document;
     QString m_scoreId;
     ModelId m_mainModel;
 
-    View *m_topView;
-    View *m_bottomView;
+    Pane *m_topPane;
+    Pane *m_bottomPane;
     Layer *m_timeRulerLayer;
     WaveformLayer *m_waveformLayer;
     SpectrogramLayer *m_spectrogramLayer;

--- a/main/Session.h
+++ b/main/Session.h
@@ -53,7 +53,11 @@ public:
     
     TimeValueLayer *getTempoLayer();
     Pane *getPaneContainingTempoLayer();
-                                                        
+
+signals:
+    void alignmentAccepted();
+    void alignmentFrameIlluminated(sv_frame_t);
+                                       
 protected slots:
     void modelReady(ModelId);
     


### PR DESCRIPTION
This PR loads the `.sposx` file if present, and uses its labels for the start and end times shown for score selection.

I am not sure that all of the sposx file labels are correct - e.g. the labels shown in the Bach are generally good but those in the Mozart example are often one or two ticks out. I was unable to spot a cause in the code, so if you can check those labels in the sposx file please do - let me know if you think the labels are good and if so I'll check the code again...

(The PR also includes a couple of other code-housekeeping commits, as well as a reset button for the score selection)

