### PR TITLE
Fixes to alignment accept/reject, score selection status, calculation of tempo curve

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -215,6 +215,10 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
 
     SVDEBUG << "MainWindow: Creating main user interface layout" << endl;
 
+    // For Piano Precision, we want to constrain playback to selection
+    // by default
+    m_viewManager->setPlaySelectionMode(true);
+
     QFrame *frame = new QFrame;
     setCentralWidget(frame);
 
@@ -2887,7 +2891,7 @@ MainWindow::setupToolbars()
             m_recordAction, SLOT(setEnabled(bool)));
 
     toolbar = addToolBar(tr("Play Mode Toolbar"));
-
+    
     m_playSelectionAction = toolbar->addAction(il.load("playselection"),
                                                tr("Constrain Playback to Selection"));
     m_playSelectionAction->setCheckable(true);

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -295,20 +295,19 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
     
     QLabel *selectFromLabel = new QLabel(tr("From:"));
     m_selectFrom = new QLabel(tr("Start"));
-    QPushButton *selectFromButton = new QPushButton(tr("Choose"));
-    selectFromButton->setCheckable(true);
-    selectGroup->addButton(selectFromButton);
+    m_selectFromButton = new QPushButton(tr("Choose"));
+    m_selectFromButton->setCheckable(true);
+    selectGroup->addButton(m_selectFromButton);
 
     QLabel *selectToLabel = new QLabel(tr("To:"));
     m_selectTo = new QLabel(tr("End"));
-    QPushButton *selectToButton = new QPushButton(tr("Choose"));
-    selectToButton->setCheckable(true);
-    selectGroup->addButton(selectToButton);
+    m_selectToButton = new QPushButton(tr("Choose"));
+    m_selectToButton->setCheckable(true);
+    selectGroup->addButton(m_selectToButton);
 
-    connect(selectFromButton, &QPushButton::toggled, [=] (bool checked) {
+    connect(m_selectFromButton, &QPushButton::toggled, [this] (bool checked) {
         SVDEBUG << "selectFromButton toggled: checked = " << checked << endl;
         if (checked) {
-            selectToButton->setChecked(false);
             m_scoreWidget->setInteractionMode
                 (ScoreWidget::InteractionMode::SelectStart);
         } else {
@@ -316,10 +315,9 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
                 (ScoreWidget::InteractionMode::Navigate);
         }
     });
-    connect(selectToButton, &QPushButton::toggled, [=] (bool checked) {
-        SVDEBUG << "selectToButton toggled: checked = " << checked << endl;
+    connect(m_selectToButton, &QPushButton::toggled, [this] (bool checked) {
+        SVDEBUG << "m_selectToButton toggled: checked = " << checked << endl;
         if (checked) {
-            selectFromButton->setChecked(false);
             m_scoreWidget->setInteractionMode
                 (ScoreWidget::InteractionMode::SelectEnd);
         } else {
@@ -335,10 +333,10 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
     
     selectionLayout->addWidget(new QLabel(" "), 0, 0);
     selectionLayout->addWidget(selectFromLabel, 0, 1, Qt::AlignRight);
-    selectionLayout->addWidget(selectFromButton, 0, 2);
+    selectionLayout->addWidget(m_selectFromButton, 0, 2);
     selectionLayout->addWidget(m_selectFrom, 0, 3);
     selectionLayout->addWidget(selectToLabel, 1, 1, Qt::AlignRight);
-    selectionLayout->addWidget(selectToButton, 1, 2);
+    selectionLayout->addWidget(m_selectToButton, 1, 2);
     selectionLayout->addWidget(m_selectTo, 1, 3);
     selectionLayout->addWidget(m_resetSelectionButton, 1, 4);
     selectionLayout->setColumnStretch(3, 10);
@@ -2372,21 +2370,12 @@ MainWindow::chooseScore() // Added by YJ Oct 5, 2021
         return;
     }
 
+    m_scoreWidget->setInteractionMode(ScoreWidget::InteractionMode::Navigate);
+    
     m_scoreId = scoreName;
-/*!!!    
-    std::string templateFile =
-        ScoreFinder::getScoreFile(scoreName.toStdString(), "svt");
-    if (templateFile == "") {
-        QMessageBox::warning(this,
-                             tr("Unable to load score session template"),
-                             tr("Unable to load score session template: alignment and analysis will not be available. See log file for more information."),
-                             QMessageBox::Ok);
-        return;
-    }
-*/    
+
     QSettings settings;
     settings.beginGroup("MainWindow");
-//!!!    settings.setValue("sessiontemplate", QString::fromStdString(templateFile));
     settings.setValue("sessiontemplate", "");
     settings.endGroup();
     
@@ -2604,6 +2593,11 @@ MainWindow::scoreInteractionModeChanged(ScoreWidget::InteractionMode mode)
             break;
         }
     }
+
+    m_selectFromButton->setChecked
+        (mode == ScoreWidget::InteractionMode::SelectStart);
+    m_selectToButton->setChecked
+        (mode == ScoreWidget::InteractionMode::SelectEnd);
 }
 
 void

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -140,7 +140,9 @@ protected slots:
     void scorePositionActivated(int, ScoreWidget::InteractionMode);
     void actOnScorePosition(int, ScoreWidget::InteractionMode, bool activated);
     void scoreInteractionEnded(ScoreWidget::InteractionMode);
+    void alignmentReadyForReview();
     void alignmentAccepted();
+    void alignmentRejected();
     void alignmentFrameIlluminated(sv_frame_t);
     void highlightFrameInScore(sv_frame_t);
     void scoreSelectionChanged(int, bool, QString, int, bool, QString);
@@ -208,6 +210,9 @@ protected:
     QScrollArea             *m_mainScroll;
     ScoreWidget             *m_scoreWidget; // Added Oct 6, 2021
     QPushButton             *m_alignButton;
+    QPushButton             *m_alignAcceptButton;
+    QPushButton             *m_alignRejectButton;
+    QWidget                 *m_alignAcceptReject;
     QPushButton             *m_scorePageDownButton;
     QPushButton             *m_scorePageUpButton;
     QLabel                  *m_scorePageLabel;

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -216,7 +216,9 @@ protected:
     QPushButton             *m_scorePageDownButton;
     QPushButton             *m_scorePageUpButton;
     QLabel                  *m_scorePageLabel;
+    QPushButton             *m_selectFromButton;
     QLabel                  *m_selectFrom;
+    QPushButton             *m_selectToButton;
     QLabel                  *m_selectTo;
     QPushButton             *m_resetSelectionButton;
 

--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -87,6 +87,8 @@ ScoreWidget::loadAScore(QString scoreName, QString &errorString)
     SVDEBUG << "ScoreWidget::loadAScore: Score \"" << scoreName
             << "\" requested" << endl;
 
+    clearSelection();
+    
     m_page = -1;
     
     string scorePath =

--- a/main/ScoreWidget.h
+++ b/main/ScoreWidget.h
@@ -68,7 +68,13 @@ public:
     /**
      * Mode for mouse interaction.
      */
-    enum class InteractionMode { None, Navigate, Edit, SelectStart, SelectEnd };
+    enum class InteractionMode {
+        None,
+        Navigate,
+        Edit,
+        SelectStart,
+        SelectEnd
+    };
 
     /**
      * Return the current interaction mode.

--- a/main/Session.h
+++ b/main/Session.h
@@ -32,6 +32,16 @@ public:
     Session();
     virtual ~Session();
 
+    TimeValueLayer *getOnsetsLayer();
+    Pane *getPaneContainingOnsetsLayer();
+    
+    TimeValueLayer *getTempoLayer();
+    Pane *getPaneContainingTempoLayer();
+
+    bool exportAlignmentTo(QString filename);
+    bool importAlignmentFrom(QString filename);
+
+public slots:
     void setDocument(Document *,
                      Pane *topPane,
                      Pane *bottomPane,
@@ -47,18 +57,13 @@ public:
                                int scorePositionEnd,
                                sv_frame_t audioFrameStart,
                                sv_frame_t audioFrameEnd);
-
-    TimeValueLayer *getOnsetsLayer();
-    Pane *getPaneContainingOnsetsLayer();
-    
-    TimeValueLayer *getTempoLayer();
-    Pane *getPaneContainingTempoLayer();
-
-    bool exportAlignmentTo(QString filename);
-    bool importAlignmentFrom(QString filename);
+    void acceptAlignment();
+    void rejectAlignment();
     
 signals:
+    void alignmentReadyForReview();
     void alignmentAccepted();
+    void alignmentRejected();
     void alignmentFrameIlluminated(sv_frame_t);
                                        
 protected slots:
@@ -80,11 +85,13 @@ private:
     sv_frame_t m_partialAlignmentAudioStart;
     sv_frame_t m_partialAlignmentAudioEnd;
     
-    TimeValueLayer *m_onsetsLayer;
+    TimeValueLayer *m_displayedOnsetsLayer;
+    TimeValueLayer *m_acceptedOnsetsLayer;
     TimeValueLayer *m_pendingOnsetsLayer;
     bool m_awaitingOnsetsLayer;
     
-    TimeValueLayer *m_tempoLayer;
+    TimeValueLayer *m_displayedTempoLayer;
+    TimeValueLayer *m_acceptedTempoLayer;
     TimeValueLayer *m_pendingTempoLayer;
     bool m_awaitingTempoLayer;
 

--- a/main/Session.h
+++ b/main/Session.h
@@ -90,14 +90,12 @@ private:
     TimeValueLayer *m_pendingOnsetsLayer;
     bool m_awaitingOnsetsLayer;
     
-    TimeValueLayer *m_displayedTempoLayer;
-    TimeValueLayer *m_acceptedTempoLayer;
-    TimeValueLayer *m_pendingTempoLayer;
-    bool m_awaitingTempoLayer;
+    TimeValueLayer *m_tempoLayer;
 
     void alignmentComplete();
     void mergeLayers(TimeValueLayer *from, TimeValueLayer *to,
                      sv_frame_t overlapStart, sv_frame_t overlapEnd);
+    void recalculateTempoLayer();
 };
 
 #endif

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -13,7 +13,7 @@
       "pin": "a831622fe4f86b95390dfc4d4be7eeee388f4e4e"
     },
     "checker": {
-      "pin": "ed75cff475c72381aedad936c72b93b4f38157d3"
+      "pin": "4f7381d34a6a1d6de73e84ff564e6ac734986d40"
     },
     "sv-dependency-builds": {
       "pin": "f4eb0637efbbb54bdd909625640b245e606a8374"
@@ -49,7 +49,7 @@
       "pin": "2e4bd170f57f"
     },
     "piano-precision-aligner": {
-      "pin": "a860de286a01d9f26d4505d165c10e5fbc4bc3f7"
+      "pin": "113ffa80e662ba7d393360b2698e25819bda0cdd"
     }
   }
 }


### PR DESCRIPTION
Fixes to a few of the items raised this week. Note that this does not yet change anything to do with save/reload of alignment to CSV.

* Constrain Playback to Selection is now on by default.
* The dialog box that appeared after an alignment had been completed (asking whether to accept it) has been replaced by two accept/reject buttons that replace the alignment button over by the score widget. You can continue navigating and working before making a decision, but you can't run an alignment again until you've accepted or rejected the previous one.
* The tempo curve is now generated entirely in the host program and is recalculated every time the alignment onsets data changes for any reason.
* The score selection status in UI is now updated when a new score is loaded (i.e. the selection is reset and the UI reflects this).

