### PR TITLE
Add the logic that actually saves to CSV

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -765,14 +765,14 @@ MainWindow::setupFileMenu()
     action = new QAction(tr("Load Score Alignment..."), this);
     action->setStatusTip(tr("Import score alignment data from a previously-saved file"));
     connect(action, SIGNAL(triggered()), this, SLOT(loadScoreAlignment()));
-    connect(this, SIGNAL(canImportLayer(bool)), action, SLOT(setEnabled(bool)));
+    connect(this, SIGNAL(canLoadScoreAlignment(bool)), action, SLOT(setEnabled(bool)));
     m_keyReference->registerShortcut(action);
     menu->addAction(action);
 
     action = new QAction(tr("Save Score Alignment..."), this);
     action->setStatusTip(tr("Export score alignment data to a file"));
     connect(action, SIGNAL(triggered()), this, SLOT(saveScoreAlignment()));
-    connect(this, SIGNAL(canExportLayer(bool)), action, SLOT(setEnabled(bool)));
+    connect(this, SIGNAL(canSaveScoreAlignment(bool)), action, SLOT(setEnabled(bool)));
     m_keyReference->registerShortcut(action);
     menu->addAction(action);
 
@@ -2713,6 +2713,8 @@ MainWindow::alignmentReadyForReview()
 
     m_alignButton->hide();
     m_alignAcceptReject->show();
+
+    updateMenuStates();
 }
 
 void
@@ -2732,6 +2734,8 @@ MainWindow::alignmentAccepted()
     }
 
     m_paneStack->setCurrentLayer(onsetsPane, onsetsLayer);
+
+    updateMenuStates();
 }
 
 void
@@ -2751,6 +2755,8 @@ MainWindow::alignmentRejected()
     }
 
     m_paneStack->setCurrentLayer(onsetsPane, onsetsLayer);
+
+    updateMenuStates();
 }
 
 void
@@ -3311,6 +3317,17 @@ MainWindow::updateMenuStates()
         }
     }
 
+    bool haveMainModel =
+        (!getMainModelId().isNone());
+
+    emit canSaveScoreAlignment(haveMainModel &&
+                               m_scoreId != "" &&
+                               !m_alignAcceptReject->isVisible());
+
+    emit canLoadScoreAlignment(haveMainModel &&
+                               m_scoreId != "" &&
+                               !m_alignAcceptReject->isVisible());
+
     updateAlignButtonText();
 }
 
@@ -3752,19 +3769,6 @@ void
 MainWindow::saveScoreAlignment()
 {
     SVDEBUG << "MainWindow::saveScoreAlignment" << endl;
-
-    TimeValueLayer *onsetsLayer = m_session.getOnsetsLayer();
-    if (!onsetsLayer) {
-        SVDEBUG << "MainWindow::saveScoreAlignment: can't find an onsets layer!" << endl;
-        return;
-    }
-
-    /*!!!
-    QDateTime now = QDateTime::currentDateTime();
-    QString nowString = now.toString("yyyyMMdd-HHmmss-zzz");
-    QString filename = RecordDirectory::getRecordDirectory() +
-        QString("/onsets-%1-unmodified.csv").arg(nowString);
-    */
 
     QString filename = getSaveFileName(FileFinder::CSVFile);
     if (filename == "") {

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -46,6 +46,8 @@ public:
 signals:
     void canChangeSolo(bool);
     void canAlign(bool);
+    void canSaveScoreAlignment(bool);
+    void canLoadScoreAlignment(bool);
 
 public slots:
     void preferenceChanged(PropertyContainer::PropertyName) override;

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -192,7 +192,7 @@ protected slots:
     virtual void saveSessionAsTemplate();
     virtual void manageSavedTemplates();
 
-    virtual QString getDefaultSessionTemplate() const;
+    virtual QString getDefaultSessionTemplate() const override;
 
     virtual void website();
     virtual void help();

--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -25,7 +25,7 @@
 
 static QColor navigateHighlightColour("#59c4df");
 static QColor editHighlightColour("#ffbd00");
-static QColor selectHighlightColour("#913d88");
+static QColor selectHighlightColour(150, 150, 255);
 
 using std::vector;
 using std::pair;
@@ -535,7 +535,7 @@ ScoreWidget::paintEvent(QPaintEvent *e)
                 break;
             case InteractionMode::SelectStart:
             case InteractionMode::SelectEnd:
-                highlightColour = selectHighlightColour;
+                highlightColour = selectHighlightColour.darker();
                 break;
             default: // None already handled in conditional above
                 throw std::runtime_error("Unhandled case in mode switch");
@@ -565,7 +565,7 @@ ScoreWidget::paintEvent(QPaintEvent *e)
          (m_mode == InteractionMode::SelectStart ||
           m_mode == InteractionMode::SelectEnd))) {
 
-        QColor fillColour = selectHighlightColour.lighter();
+        QColor fillColour = selectHighlightColour;
         fillColour.setAlpha(100);
         paint.setPen(Qt::NoPen);
         paint.setBrush(fillColour);

--- a/main/Session.h
+++ b/main/Session.h
@@ -36,7 +36,7 @@ public:
 
     struct AlignmentEntry
     {
-        string label;
+        std::string label;
         float tick;
         int frame;
 
@@ -109,6 +109,9 @@ private:
     void mergeLayers(TimeValueLayer *from, TimeValueLayer *to,
                      sv_frame_t overlapStart, sv_frame_t overlapEnd);
     void recalculateTempoLayer();
+
+    bool exportAlignmentEntriesTo(QString path,
+                                  const std::vector<AlignmentEntry> &entries);
 
     const Score::MusicalEventList *m_musicalEvents; // I don't own this.
 };


### PR DESCRIPTION
This PR adds the code to actually save musical event data to CSV.

There is also a logical change in `Session::exportAlignmentTo`, to make the export go ahead even if there is no alignment available - so that the user can export an empty alignment in order to get a CSV file with "template" musical event data only. Since the export code doesn't actually need an alignment any more, we can go ahead both with and without it.

Also a few changes to the UI state handling in `MainWindow` - it was possible to get in a mess by e.g. opening a new file while the UI was still waiting for an alignment to be accepted or rejected, so now opening a new file also rejects the alignment.

Similarly I've made it so that you can't export an alignment that has not yet been accepted or rejected - nor can you load one to replace it - since it was pretty ambiguous what that would lead to, and it would probably only happen because the user had forgotten to accept.

I haven't made any interesting decisions about what the CSV format should look like, so do adjust the content of `exportAlignmentEntriesTo` to taste. Once the saved format is settled, we can readily enough update the import code as well.

