### PR TITLE
Fix failure to reactivate the Save Alignment button when the alignment was edited by user

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -519,6 +519,8 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
 
     connect(&m_session, SIGNAL(alignmentReadyForReview()),
             this, SLOT(alignmentReadyForReview()));
+    connect(&m_session, SIGNAL(alignmentModified()),
+            this, SLOT(alignmentModified()));
     connect(&m_session, SIGNAL(alignmentAccepted()),
             this, SLOT(alignmentAccepted()));
     connect(&m_session, SIGNAL(alignmentRejected()),
@@ -2743,6 +2745,15 @@ MainWindow::alignmentReadyForReview()
     m_alignButton->hide();
     m_alignAcceptReject->show();
 
+    updateMenuStates();
+}
+
+void
+MainWindow::alignmentModified()
+{
+    SVDEBUG << "MainWindow::alignmentModified" << endl;
+
+    m_scoreAlignmentModified = true;
     updateMenuStates();
 }
 

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -147,6 +147,7 @@ protected slots:
     void actOnScorePosition(int, ScoreWidget::InteractionMode, bool activated);
     void scoreInteractionEnded(ScoreWidget::InteractionMode);
     void alignmentReadyForReview();
+    void alignmentModified();
     void alignmentAccepted();
     void alignmentRejected();
     void alignmentFrameIlluminated(sv_frame_t);

--- a/main/Session.h
+++ b/main/Session.h
@@ -78,9 +78,11 @@ signals:
     void alignmentReadyForReview();
     void alignmentAccepted();
     void alignmentRejected();
+    void alignmentModified();
     void alignmentFrameIlluminated(sv_frame_t);
                                        
 protected slots:
+    void modelChanged(ModelId);
     void modelReady(ModelId);
     
 private:

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -4,7 +4,7 @@
       "pin": "7df85ecf98d9477c1ac5a36f51807062e00d8695"
     },
     "svcore": {
-      "pin": "1706fe073070cbfcd2459a0cfd2b738997dcf85a"
+      "pin": "719a0fbfc193a67c630ffd5ea3949faac079ade6"
     },
     "svgui": {
       "pin": "ef0e579917c0c9aed151df7cae3506130ea55a05"


### PR DESCRIPTION
This also (as a side-effect) makes dynamic recalculation of the tempo curve while editing work, something we talked about but one point but that was not actually on the list.
