### PR TITLE
Use the system extents to establish highlight rects

### DIFF
--- a/main/ScoreWidget.h
+++ b/main/ScoreWidget.h
@@ -21,6 +21,7 @@
 #include "piano-precision-aligner/Score.h"
 
 class QSvgRenderer;
+class QDomElement;
 
 class ScoreWidget : public QFrame
 {
@@ -167,8 +168,9 @@ protected:
     
 private:
     /**
-     * EventId is for MEI-derived note IDs used within this class to
-     * identify specific elements. These are not used in the API.
+     * EventId is for MEI-derived note IDs (or other MEI element IDs)
+     * used within this class to identify specific elements. These are
+     * not exposed in the API.
      */
     typedef QString EventId;
     
@@ -191,6 +193,15 @@ private:
 
         bool isNull() const { return id == ""; }
     };
+
+    // MEI id-to-extent relations: these are generated from the SVG
+    // XML when the score is loaded
+    typedef std::pair<double, double> Extent;
+    std::map<EventId, Extent> m_noteSystemExtentMap;
+
+    // Relations between MEI IDs and musical events: these are
+    // generated when the musical event data is set, after the score
+    // has been loaded
     std::map<EventId, EventData> m_idDataMap;
     std::map<EventLabel, EventId> m_labelIdMap;
     std::map<int, std::vector<EventId>> m_pageEventsMap;
@@ -215,6 +226,11 @@ private:
     bool isSelectedFromStart() const;
     bool isSelectedToEnd() const;
     bool isSelectedAll() const;
+
+    QRectF getHighlightRectFor(const EventData &);
+    
+    void findSystemExtents(QByteArray, std::shared_ptr<QSvgRenderer>);
+    void assignExtentToNotesBelow(const QDomElement &, Extent);
     
     QTransform m_widgetToPage;
     QTransform m_pageToWidget;


### PR DESCRIPTION
This modifies the highlight areas (for mouse interaction and selection) so as to use the full system height.

The mechanism is inspired by your suggestion based on measure elements, but it works top-down instead of bottom-up and looks for system elements rather than measure ones.

The top-down part (searching through the page tree downwards from the document root) is because we really want to perform this lookup all in one go, when the document is loaded and we have access to the SVG XML - so we might as well read the tree system-by-system. At the later moment when we actually want to draw something, we only have the opaque SVG renderer available to us and it seems a shame to have to refer back to the raw XML then. Also, it is just a bit easier to descend through the tree than ascend up it.

The use of system elements instead of measure elements is solely because it was a bit simpler. It takes the system height from the vertical bar that is the first element in the system. I have only tested this so far with one single piece, the Mozart - if it turns out that this isn't good enough (e.g. because single-staff systems have no system group or vertical bar) it should be easy enough to change, now that the general logic is known to work.

