### PR TITLE
Move code to unpack Verovio resources into ScoreParser, and use it there

### DIFF
--- a/main/ScoreParser.h
+++ b/main/ScoreParser.h
@@ -21,6 +21,13 @@ public:
     /** Generate necessary score files.
      */
     static bool generateScoreFiles(std::string scorePath, std::string scoreName);
+
+    /** Obtain the resource path to pass to Verovio. Resources are
+     *  unpacked from the binary bundle the first time this is called,
+     *  so the resulting resource path is local to this invocation of
+     *  the program.
+     */
+    static std::string getResourcePath();
 };
 
 #endif

--- a/main/ScoreWidget.h
+++ b/main/ScoreWidget.h
@@ -176,8 +176,7 @@ private:
     
     QString m_scoreName;
     QString m_scoreFilename;
-    QTemporaryDir m_tempDir;
-    QString m_verovioResourcePath;
+    std::string m_verovioResourcePath;
     std::vector<std::shared_ptr<QSvgRenderer>> m_svgPages;
     int m_page;
 


### PR DESCRIPTION
The resource directory for Verovio is unpacked from the binary the first time it's needed. (It's packaged into the binary using the Qt resource mechanism, see the end of `piano-precision.qrc`.)

Until now this has been done by `ScoreWidget`, but it's needed in `ScoreParser` as well and we probably don't want a dependency from there to `ScoreWidget`. So this commit moves the unpacking code from `ScoreWidget` to `ScoreParser` and makes use of it there. I've checked that this works for me.

Note that the unpacking code (of necessity) depends on Qt. If we need to use this from anything that is not compiled against Qt (e.g. the plugin) we'll have to come up with something else. If that's not an issue but you would prefer not to use Qt within this specific source file (which is otherwise independent of Qt) then we can always move the code out to a separate common file.
