### PR TITLE
Handle plugin outputs that now lack values

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -2506,13 +2506,13 @@ MainWindow::highlightFrameInScore(sv_frame_t frame)
 
     // The default tempo is quarter note = 120 bpm.
 
-    TimeValueLayer *targetLayer = m_session.getOnsetsLayer();
+    TimeInstantLayer *targetLayer = m_session.getOnsetsLayer();
 
     // If the program is slow, might want to consider a different approach that can get rid of the loops.
     QString label;
     if (targetLayer) {
         ModelId targetId = targetLayer->getModel();
-        const auto targetModel = ModelById::getAs<SparseTimeValueModel>(targetId);
+        const auto targetModel = ModelById::getAs<SparseOneDimensionalModel>(targetId);
         const auto events = targetModel->getAllEvents();
         if (events.empty()) return;
         label = events[0].getLabel();
@@ -2694,7 +2694,7 @@ MainWindow::actOnScoreLocation(Fraction location,
     
     // See comments in highlightFrameInScore above
 
-    TimeValueLayer *targetLayer = m_session.getOnsetsLayer();
+    TimeInstantLayer *targetLayer = m_session.getOnsetsLayer();
     Pane *targetPane = m_session.getPaneContainingOnsetsLayer();
 
     if (!targetLayer || !targetPane || !m_viewManager) {
@@ -2702,11 +2702,11 @@ MainWindow::actOnScoreLocation(Fraction location,
         return;
     }
 
-    targetLayer->setPermitValueEditOfSegmentation(false);
+//    targetLayer->setPermitValueEditOfSegmentation(false);
     m_paneStack->setCurrentLayer(targetPane, targetLayer);
 
     ModelId targetId = targetLayer->getModel();
-    const auto targetModel = ModelById::getAs<SparseTimeValueModel>(targetId);
+    const auto targetModel = ModelById::getAs<SparseOneDimensionalModel>(targetId);
     if (!targetModel) {
         SVDEBUG << "MainWindow::actOnScorePosition: missing target model" << endl;
         return;
@@ -2738,7 +2738,7 @@ MainWindow::actOnScoreLocation(Fraction location,
 void
 MainWindow::scoreInteractionEnded(ScoreWidget::InteractionMode mode)
 {
-    TimeValueLayer *targetLayer = m_session.getOnsetsLayer();
+    TimeInstantLayer *targetLayer = m_session.getOnsetsLayer();
     if (targetLayer) {
         targetLayer->removeOverrideHighlight();
     }
@@ -2764,7 +2764,7 @@ MainWindow::alignmentReadyForReview()
 {
     SVDEBUG << "MainWindow::alignmentReadyForReview" << endl;
 
-    TimeValueLayer *onsetsLayer = m_session.getOnsetsLayer();
+    TimeInstantLayer *onsetsLayer = m_session.getOnsetsLayer();
     Pane *onsetsPane = m_session.getPaneContainingOnsetsLayer();
     if (!onsetsLayer) {
         SVDEBUG << "MainWindow::alignmentReadyForReview: can't find an onsets layer!" << endl;
@@ -2797,7 +2797,7 @@ MainWindow::alignmentAccepted()
     m_alignButton->show();
     m_alignButton->setEnabled(true);
 
-    TimeValueLayer *onsetsLayer = m_session.getOnsetsLayer();
+    TimeInstantLayer *onsetsLayer = m_session.getOnsetsLayer();
     Pane *onsetsPane = m_session.getPaneContainingOnsetsLayer();
     if (!onsetsLayer) {
         SVDEBUG << "MainWindow::alignmentAccepted: can't find an onsets layer!" << endl;
@@ -2820,7 +2820,7 @@ MainWindow::alignmentRejected()
     m_alignButton->show();
     m_alignButton->setEnabled(true);
 
-    TimeValueLayer *onsetsLayer = m_session.getOnsetsLayer();
+    TimeInstantLayer *onsetsLayer = m_session.getOnsetsLayer();
     Pane *onsetsPane = m_session.getPaneContainingOnsetsLayer();
     if (!onsetsLayer) {
         SVDEBUG << "MainWindow::alignmentRejected: can't find an onsets layer!" << endl;

--- a/main/Session.h
+++ b/main/Session.h
@@ -18,6 +18,7 @@
 #include "layer/TimeRulerLayer.h"
 #include "layer/WaveformLayer.h"
 #include "layer/SpectrogramLayer.h"
+#include "layer/TimeInstantLayer.h"
 #include "layer/TimeValueLayer.h"
 
 #include "view/Pane.h"
@@ -43,7 +44,7 @@ public:
         AlignmentEntry(std::string l, float t, int f): label{l}, time{t}, frame{f} { }
     };
 
-    sv::TimeValueLayer *getOnsetsLayer();
+    sv::TimeInstantLayer *getOnsetsLayer();
     sv::Pane *getPaneContainingOnsetsLayer();
     
     sv::TimeValueLayer *getTempoLayer();
@@ -103,16 +104,16 @@ private:
     sv::sv_frame_t m_partialAlignmentAudioStart;
     sv::sv_frame_t m_partialAlignmentAudioEnd;
     
-    sv::TimeValueLayer *m_displayedOnsetsLayer;
-    sv::TimeValueLayer *m_acceptedOnsetsLayer;
-    sv::TimeValueLayer *m_pendingOnsetsLayer;
+    sv::TimeInstantLayer *m_displayedOnsetsLayer;
+    sv::TimeInstantLayer *m_acceptedOnsetsLayer;
+    sv::TimeInstantLayer *m_pendingOnsetsLayer;
     bool m_awaitingOnsetsLayer;
     
     sv::TimeValueLayer *m_tempoLayer;
 
-    void setOnsetsLayerProperties(sv::TimeValueLayer *);
+    void setOnsetsLayerProperties(sv::TimeInstantLayer *);
     void alignmentComplete();
-    void mergeLayers(sv::TimeValueLayer *from, sv::TimeValueLayer *to,
+    void mergeLayers(sv::TimeInstantLayer *from, sv::TimeInstantLayer *to,
                      sv::sv_frame_t overlapStart, sv::sv_frame_t overlapEnd);
     void recalculateTempoLayer();
 

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -7,7 +7,7 @@
       "pin": "94a973c7aeeb3614e7dcf70b157a13176f030a58"
     },
     "svgui": {
-      "pin": "afb60710489066a07e4b83ff922e7672b691f93a"
+      "pin": "1cecdcd92e876b358c8dbe1d7b9ad61a15daceae"
     },
     "svapp": {
       "pin": "d07286b92a4220ae47149ddec980640cb58d16de"


### PR DESCRIPTION
This change follows the aligner plugin update that removes the values from returned onset features. Those features now go into a time-instant layer rather than a time-value layer, and the host needs to be aware of this and to refer to the proper layer appropriately.

Note that the onsets are now displayed in a different colour from before - this is just the default behaviour of the time-instant layer. It can be changed in `Session::setOnsetsLayerProperties` with a call to `onsetsLayer->setBaseColour` - search the file for other references to `setBaseColour` to see examples if you would like to do this. I don't think we ever actually specified a colour for the previous time-value layer, I think that was also just the default (but with a different default in that layer).
