### PR TITLE
Enable support for more than one alignment plugin, with menu to select between them

### DIFF
--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -514,6 +514,8 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
             this, SLOT(alignmentRejected()));
     connect(&m_session, SIGNAL(alignmentFrameIlluminated(sv_frame_t)),
             this, SLOT(alignmentFrameIlluminated(sv_frame_t)));
+    connect(&m_session, SIGNAL(alignmentFailedToRun(QString)),
+            this, SLOT(alignmentFailedToRun(QString)));
 
     QTimer::singleShot(250, this, &MainWindow::introduction);
 
@@ -2830,6 +2832,21 @@ MainWindow::alignmentFrameIlluminated(sv_frame_t frame)
         ScoreWidget::InteractionMode::Edit) {
         highlightFrameInScore(frame);
     }
+}
+
+void
+MainWindow::alignmentFailedToRun(QString message)
+{
+    // NB we also have alignmentFailed which is received when the
+    // "classic SV" audio-to-audio alignment fails. This is for
+    // audio-to-score
+
+    QMessageBox::warning
+        (this,
+         tr("Unable to calculate alignment"),
+         tr("<b>Alignment calculation failed</b><p>Failed to align audio with score:<p>%1")
+         .arg(message),
+         QMessageBox::Ok);
 }
 
 void

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -115,7 +115,7 @@ protected slots:
     void modelGenerationWarning(QString, QString) override;
     void modelRegenerationFailed(QString, QString, QString) override;
     void modelRegenerationWarning(QString, QString, QString) override;
-    void alignmentFailed(sv::ModelId, QString) override;
+    void alignmentFailed(sv::ModelId, QString) override; // For audio-to-audio
 
     void paneRightButtonMenuRequested(sv::Pane *, QPoint point) override;
     void panePropertiesRightButtonMenuRequested(sv::Pane *, QPoint point) override;
@@ -158,6 +158,7 @@ protected slots:
     void alignmentAccepted();
     void alignmentRejected();
     void alignmentFrameIlluminated(sv::sv_frame_t);
+    void alignmentFailedToRun(QString);
     void highlightFrameInScore(sv::sv_frame_t);
     void scoreSelectionChanged(Fraction, bool, ScoreWidget::EventLabel, Fraction, bool, ScoreWidget::EventLabel);
     void scorePageChanged(int page);

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -161,6 +161,7 @@ protected slots:
     void alignmentFrameIlluminated(sv::sv_frame_t);
     void alignmentFailedToRun(QString);
     void populateScoreAlignerChoiceMenu();
+    void scoreAlignerChosen(sv::TransformId);
     void highlightFrameInScore(sv::sv_frame_t);
     void scoreSelectionChanged(Fraction, bool, ScoreWidget::EventLabel, Fraction, bool, ScoreWidget::EventLabel);
     void scorePageChanged(int page);

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -28,6 +28,7 @@
 
 class QFileSystemWatcher;
 class QScrollArea;
+class QToolButton;
 
 namespace sv {
 class VersionTester;
@@ -159,6 +160,7 @@ protected slots:
     void alignmentRejected();
     void alignmentFrameIlluminated(sv::sv_frame_t);
     void alignmentFailedToRun(QString);
+    void populateScoreAlignerChoiceMenu();
     void highlightFrameInScore(sv::sv_frame_t);
     void scoreSelectionChanged(Fraction, bool, ScoreWidget::EventLabel, Fraction, bool, ScoreWidget::EventLabel);
     void scorePageChanged(int page);
@@ -227,6 +229,8 @@ protected:
     QScrollArea             *m_mainScroll;
     ScoreWidget             *m_scoreWidget;
     QPushButton             *m_alignButton;
+    QToolButton             *m_alignerChoice;
+    QWidget                 *m_alignCommands;
     QPushButton             *m_alignAcceptButton;
     QPushButton             *m_alignRejectButton;
     QWidget                 *m_alignAcceptReject;

--- a/main/ScoreAlignmentTransform.cpp
+++ b/main/ScoreAlignmentTransform.cpp
@@ -69,6 +69,14 @@ ScoreAlignmentTransform::getDefaultAlignmentTransform()
     if (transforms.empty()) {
         return {};
     } else {
+        TransformId hardcodedDefaultPrefix("vamp:score-aligner:pianoaligner:");
+        for (const auto &t : transforms) {
+            if (t.identifier.startsWith(hardcodedDefaultPrefix)) {
+                SVDEBUG << "ScoreAlignmentTransform::getDefaultAlignmentTransform: Found \"" << t.identifier << "\" which starts with hardcoded default \"" << hardcodedDefaultPrefix << "\", using this" << endl;
+                return t.identifier;
+            }
+        }
+        SVDEBUG << "ScoreAlignmentTransform::getDefaultAlignmentTransform: Found nothing to match hardcoded default prefix, returning first aligner in list which is \"" << transforms.begin()->identifier << "\"" << endl;
         return transforms.begin()->identifier;
     }
 }

--- a/main/ScoreAlignmentTransform.cpp
+++ b/main/ScoreAlignmentTransform.cpp
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    SV Piano Precision
+    
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+*/
+
+#include "ScoreAlignmentTransform.h"
+
+#include "transform/TransformFactory.h"
+
+#include <QMutexLocker>
+
+using namespace sv;
+
+bool
+ScoreAlignmentTransform::m_queried = false;
+
+TransformList
+ScoreAlignmentTransform::m_transforms = {};
+
+QMutex
+ScoreAlignmentTransform::m_mutex = {};
+
+TransformList
+ScoreAlignmentTransform::getAvailableAlignmentTransforms()
+{
+    QMutexLocker locker(&m_mutex);
+    
+    if (m_queried) {
+        return m_transforms;
+    }
+
+    m_transforms.clear();
+
+    auto allTransforms =
+        TransformFactory::getInstance()->getInstalledTransformDescriptions();
+    
+    for (const auto &desc : allTransforms) {
+        TransformId identifier = desc.identifier;
+        Transform transform;
+        transform.setIdentifier(identifier);
+        SVDEBUG << "Session::findAlignmentTransform: looking at transform "
+                << identifier << " with output \"" << transform.getOutput()
+                << "\"" << endl;
+        if (transform.getOutput() == "chordonsets") {
+            SVDEBUG << "Session::findAlignmentTransform: it's a candidate" << endl;
+            m_transforms.push_back(desc);
+        }
+    }
+
+    return m_transforms;
+}
+
+TransformId
+ScoreAlignmentTransform::getDefaultAlignmentTransform()
+{
+    // We return a TransformId rather than a filled-out Transform
+    // because the latter depends on sample rate of input, which we
+    // can't know at this point
+    
+    auto transforms = getAvailableAlignmentTransforms();
+    if (transforms.empty()) {
+        return {};
+    } else {
+        return transforms.begin()->identifier;
+    }
+}

--- a/main/ScoreAlignmentTransform.cpp
+++ b/main/ScoreAlignmentTransform.cpp
@@ -18,6 +18,8 @@
 
 using namespace sv;
 
+const QString ALIGNMENT_OUTPUT_NAME = "audio-to-score-alignment";
+
 bool
 ScoreAlignmentTransform::m_queried = false;
 
@@ -40,7 +42,7 @@ ScoreAlignmentTransform::getAvailableAlignmentTransforms()
 
     auto allTransforms =
         TransformFactory::getInstance()->getInstalledTransformDescriptions();
-    
+
     for (const auto &desc : allTransforms) {
         TransformId identifier = desc.identifier;
         Transform transform;
@@ -48,7 +50,7 @@ ScoreAlignmentTransform::getAvailableAlignmentTransforms()
         SVDEBUG << "ScoreAlignmentTransform: looking at transform "
                 << identifier << " with output \"" << transform.getOutput()
                 << "\"" << endl;
-        if (transform.getOutput() == "chordonsets") {
+        if (transform.getOutput() == ALIGNMENT_OUTPUT_NAME) {
             SVDEBUG << "ScoreAlignmentTransform: it's a candidate" << endl;
             m_transforms.push_back(desc);
         }

--- a/main/ScoreAlignmentTransform.cpp
+++ b/main/ScoreAlignmentTransform.cpp
@@ -54,6 +54,7 @@ ScoreAlignmentTransform::getAvailableAlignmentTransforms()
         }
     }
 
+    m_queried = true;
     return m_transforms;
 }
 

--- a/main/ScoreAlignmentTransform.cpp
+++ b/main/ScoreAlignmentTransform.cpp
@@ -45,11 +45,11 @@ ScoreAlignmentTransform::getAvailableAlignmentTransforms()
         TransformId identifier = desc.identifier;
         Transform transform;
         transform.setIdentifier(identifier);
-        SVDEBUG << "Session::findAlignmentTransform: looking at transform "
+        SVDEBUG << "ScoreAlignmentTransform: looking at transform "
                 << identifier << " with output \"" << transform.getOutput()
                 << "\"" << endl;
         if (transform.getOutput() == "chordonsets") {
-            SVDEBUG << "Session::findAlignmentTransform: it's a candidate" << endl;
+            SVDEBUG << "ScoreAlignmentTransform: it's a candidate" << endl;
             m_transforms.push_back(desc);
         }
     }

--- a/main/ScoreAlignmentTransform.cpp
+++ b/main/ScoreAlignmentTransform.cpp
@@ -19,6 +19,7 @@
 using namespace sv;
 
 const QString ALIGNMENT_OUTPUT_NAME = "audio-to-score-alignment";
+const QString DEFAULT_PREFIX = "vamp:score-aligner:pianoaligner:";
 
 bool
 ScoreAlignmentTransform::m_queried = false;
@@ -71,10 +72,9 @@ ScoreAlignmentTransform::getDefaultAlignmentTransform()
     if (transforms.empty()) {
         return {};
     } else {
-        TransformId hardcodedDefaultPrefix("vamp:score-aligner:pianoaligner:");
         for (const auto &t : transforms) {
-            if (t.identifier.startsWith(hardcodedDefaultPrefix)) {
-                SVDEBUG << "ScoreAlignmentTransform::getDefaultAlignmentTransform: Found \"" << t.identifier << "\" which starts with hardcoded default \"" << hardcodedDefaultPrefix << "\", using this" << endl;
+            if (t.identifier.startsWith(DEFAULT_PREFIX)) {
+                SVDEBUG << "ScoreAlignmentTransform::getDefaultAlignmentTransform: Found \"" << t.identifier << "\" which starts with hardcoded default \"" << DEFAULT_PREFIX << "\", using this" << endl;
                 return t.identifier;
             }
         }

--- a/main/ScoreAlignmentTransform.h
+++ b/main/ScoreAlignmentTransform.h
@@ -1,0 +1,32 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    SV Piano Precision
+    
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+*/
+
+#ifndef SV_SCORE_ALIGNMENT_TRANSFORM_H
+#define SV_SCORE_ALIGNMENT_TRANSFORM_H
+
+#include "transform/TransformDescription.h"
+
+#include <QMutex>
+
+class ScoreAlignmentTransform
+{
+public:
+    static sv::TransformList getAvailableAlignmentTransforms();
+    static sv::TransformId getDefaultAlignmentTransform();
+
+private:
+    static QMutex m_mutex;
+    static bool m_queried;
+    static sv::TransformList m_transforms;
+};
+
+#endif

--- a/main/Session.cpp
+++ b/main/Session.cpp
@@ -154,6 +154,14 @@ Session::setMainModel(ModelId modelId, QString scoreId)
 }
 
 void
+Session::setAlignmentTransformId(TransformId alignmentTransformId)
+{
+    SVDEBUG << "Session::setAlignmentTransformId: Setting to \""
+            << alignmentTransformId << "\"" << endl;
+    m_alignmentTransformId = alignmentTransformId;
+}
+
+void
 Session::beginAlignment()
 {
     if (m_mainModel.isNone()) {
@@ -179,8 +187,11 @@ Session::beginPartialAlignment(int scorePositionStartNumerator,
 
     ModelTransformer::Input input(m_mainModel);
 
-    TransformId alignmentTransformId =
-        ScoreAlignmentTransform::getDefaultAlignmentTransform();
+    TransformId alignmentTransformId = m_alignmentTransformId;
+    if (alignmentTransformId == "") {
+        alignmentTransformId =
+            ScoreAlignmentTransform::getDefaultAlignmentTransform();
+    }
 
     if (alignmentTransformId == "") {
         SVDEBUG << "Session::beginPartialAlignment: ERROR: No alignment transform found" << endl;

--- a/main/Session.h
+++ b/main/Session.h
@@ -64,6 +64,8 @@ public slots:
     
     void setMainModel(sv::ModelId modelId, QString scoreId);
 
+    void setAlignmentTransformId(sv::TransformId transformId);
+    
     void beginAlignment();
 
     void beginPartialAlignment(int scorePositionStartNumerator,
@@ -99,6 +101,7 @@ private:
     sv::Document *m_document;
     QString m_scoreId;
     sv::ModelId m_mainModel;
+    sv::TransformId m_alignmentTransformId;
 
     sv::Pane *m_topPane;
     sv::Pane *m_bottomPane;

--- a/main/Session.h
+++ b/main/Session.h
@@ -84,6 +84,10 @@ signals:
     void alignmentRejected();
     void alignmentModified();
     void alignmentFrameIlluminated(sv::sv_frame_t);
+
+    // This indicates a technical problem starting alignment, e.g. no
+    // plugin available, not that the aligner failed to align
+    void alignmentFailedToRun(QString message);
                                        
 protected slots:
     void modelChanged(sv::ModelId);
@@ -125,8 +129,6 @@ private:
     bool updateAlignmentEntries();
     bool exportAlignmentEntriesTo(QString path);
 
-    sv::TransformId findAlignmentTransform();
-    
     Score::MusicalEventList m_musicalEvents;
     std::vector<AlignmentEntry> m_alignmentEntries;
 };

--- a/main/Session.h
+++ b/main/Session.h
@@ -125,6 +125,8 @@ private:
     bool updateAlignmentEntries();
     bool exportAlignmentEntriesTo(QString path);
 
+    sv::TransformId findAlignmentTransform();
+    
     Score::MusicalEventList m_musicalEvents;
     std::vector<AlignmentEntry> m_alignmentEntries;
 };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -410,24 +410,24 @@ main(int argc, char **argv)
     settings.setValue("rdf-indices", list);
     settings.endGroup();
 
-    PluginPathSetter::Paths paths = PluginPathSetter::getPaths();
+    PluginPathSetter::Paths paths = PluginPathSetter::getDefaultPaths();
     
     PluginPathSetter::TypeKey vampPluginTypeKey
         { KnownPlugins::VampPlugin, KnownPlugins::FormatNative };
 
     auto defaultVampConfig = paths.at(vampPluginTypeKey);
-    
-    QStringList pluginDirPaths =
-        HelperExecPath(HelperExecPath::NativeArchitectureOnly)
-        .getBundledPluginPaths();
 
     for (auto &config : paths) {
         config.second.directories = {};
         config.second.useEnvVariable = false;
     };
+    
+    QStringList bundledPluginPaths =
+        HelperExecPath(HelperExecPath::NativeArchitectureOnly)
+        .getBundledPluginPaths();
 
     paths[vampPluginTypeKey] = {
-        pluginDirPaths << defaultVampConfig.directories,
+        bundledPluginPaths << defaultVampConfig.directories,
         defaultVampConfig.envVariable,
         true // allow environment variable to override this one
     };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -410,34 +410,34 @@ main(int argc, char **argv)
     settings.setValue("rdf-indices", list);
     settings.endGroup();
 
+    PluginPathSetter::Paths paths = PluginPathSetter::getPaths();
+    
     PluginPathSetter::TypeKey vampPluginTypeKey
         { KnownPlugins::VampPlugin, KnownPlugins::FormatNative };
 
-    PluginPathSetter::TypeKey ladspaPluginTypeKey
-        { KnownPlugins::LADSPAPlugin, KnownPlugins::FormatNative };
-
+    auto defaultVampConfig = paths.at(vampPluginTypeKey);
+    
     QStringList pluginDirPaths =
         HelperExecPath(HelperExecPath::NativeArchitectureOnly)
         .getBundledPluginPaths();
-    
-    PluginPathSetter::Paths bundlePaths
-        { { vampPluginTypeKey,
-            { pluginDirPaths,
-              QString("VAMP_PATH"),
-              true              // allow environment variable to override
-            }
-            },
-          { ladspaPluginTypeKey,
-            { {},
-              QString("LADSPA_PATH"),
-              false             // do not load from system paths
-            }
-          }
-        };
 
-    PluginPathSetter::savePathSettings(bundlePaths);
+    for (auto &config : paths) {
+        config.second.directories = {};
+        config.second.useEnvVariable = false;
+    };
+
+    paths[vampPluginTypeKey] = {
+        pluginDirPaths << defaultVampConfig.directories,
+        defaultVampConfig.envVariable,
+        true // allow environment variable to override this one
+    };
+    
+    PluginPathSetter::savePathSettings(paths);
     PluginPathSetter::initialiseEnvironmentVariables();
 
+    TransformFactory::getInstance()->restrictTransformTypes
+        ({ Transform::FeatureExtraction });
+    
     ScoreFinder::initialiseAlignerEnvironmentVariables();
     ScoreFinder::populateUserDirectoriesFromBundled();
     

--- a/meson.build
+++ b/meson.build
@@ -1086,6 +1086,7 @@ pp_main_files = [
   'main/SVSplash.cpp',
   'main/PreferencesDialog.cpp',
   'main/Session.cpp',
+  'main/ScoreAlignmentTransform.cpp',
   'main/ScoreFinder.cpp',
   'main/ScoreParser.cpp',
   'main/ScoreWidget.cpp',

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -4,10 +4,10 @@
       "pin": "63e0c3b37b6fb9ce6f074ea8222b4903e4f5568a"
     },
     "svcore": {
-      "pin": "65eeb62d0c966f4c15db78ba28eab8d4a8ea0274"
+      "pin": "e423b267d1f8be85f03e4335b95e39b0f68dd3d2"
     },
     "svgui": {
-      "pin": "1202482d186f8282becfc8030199784153bd29df"
+      "pin": "2796d24d9e1918d3ed12057f801ca07c9c1032a3"
     },
     "svapp": {
       "pin": "f51a1690f3f92e2421916d39a3385d49214e60c6"
@@ -46,13 +46,13 @@
       "pin": "88520ab5b8e5"
     },
     "bqaudiostream": {
-      "pin": "73fd7555ad14"
+      "pin": "5d5950bc4d93"
     },
     "bqthingfactory": {
       "pin": "2e4bd170f57f"
     },
     "piano-precision-aligner": {
-      "pin": "9dc37de1b91b0e87d93267f97c9364f4b137bb97"
+      "pin": "5e30b8c5b998ce03d46352a84f5b9c8c0734371c"
     }
   }
 }


### PR DESCRIPTION
![Screenshot_20240712_144101](https://github.com/user-attachments/assets/530a20a5-d96d-4c73-a61c-e4bbfe5cf108)

This makes the following changes:

 * We now load all Vamp plugins found in the app bundle and the normal plugin path. (This can still be overridden with the `VAMP_PATH` environment variable.)
 * Every Vamp plugin that has an appropriately-named output (`audio-to-score-alignment`) is picked as a candidate alignment plugin
 * They are all offered in a little menu to the right of the align button; the selected one is used for alignment, and the most recent selection is remembered from one run of the program to the next
 * The default is *not*, as we had discussed, the first one that happened to have been found in the plugin bundle. It turns out that because there are so many layers between plugin loading and transform lookup in the SV code, the information about where the plugin was loaded from is no longer available at the place we need it! So if there is another solution that works equally well, that would be simpler. For the moment I have just hardcoded `score-aligner:pianoaligner` as the default.

