### PR TITLE
Fixes to button appearance and directory searches

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,14 +14,14 @@ jobs:
     - name: repoint
       run: PATH=$PATH:/usr/local/smlnj/bin ./repoint install
     - name: configure
-      run: PATH=$PATH:/usr/local/opt/qt6/bin meson setup build --buildtype release
+      run: meson setup build --buildtype release
     - name: make
       run: ninja -C build
     - name: test
       run: meson test -C build
     - name: deploy-app
       run: |
-        QTDIR=/usr/local/opt/qt6 ./deploy/macos/deploy.sh build
+        QTDIR=/opt/homebrew ./deploy/macos/deploy.sh build
     - name: check
       run: |
         otool -L ./"Piano Precision.app/Contents/MacOS/Piano Precision"

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -268,7 +268,8 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
     m_subsetOfScoreSelected = false;
 
     m_alignerChoice = new QPushButton();
-    m_alignerChoice->setMaximumWidth(24);
+    QChar dot(0x00b7);
+    m_alignerChoice->setText(QString("%1%2%3").arg(dot).arg(dot).arg(dot));
     
     m_alignCommands = new QWidget;
     QHBoxLayout *aclayout = new QHBoxLayout;

--- a/main/MainWindow.cpp
+++ b/main/MainWindow.cpp
@@ -267,22 +267,14 @@ MainWindow::MainWindow(AudioMode audioMode, MIDIMode midiMode, bool withOSCSuppo
     m_alignButton->setEnabled(false);
     m_subsetOfScoreSelected = false;
 
-    m_alignerChoice = new QToolButton();
-    m_alignerChoice->setPopupMode(QToolButton::InstantPopup);
-
-#ifdef Q_OS_MAC
-    QChar dot(0x00b7);
-    m_alignerChoice->setText(QString("%1%2%3").arg(dot).arg(dot).arg(dot));
-    m_alignerChoice->setFixedSize(22, 22);
-#else
-    m_alignerChoice->setArrowType(Qt::DownArrow);
-#endif
+    m_alignerChoice = new QPushButton();
+    m_alignerChoice->setMaximumWidth(24);
     
     m_alignCommands = new QWidget;
     QHBoxLayout *aclayout = new QHBoxLayout;
     aclayout->addWidget(m_alignButton);
     aclayout->addWidget(m_alignerChoice);
-    aclayout->setContentsMargins(0, 0, 0, 0);
+    aclayout->setContentsMargins(0, 2, 0, 0);
     m_alignCommands->setLayout(aclayout);
     
     m_alignAcceptButton = new QPushButton

--- a/main/MainWindow.h
+++ b/main/MainWindow.h
@@ -230,7 +230,7 @@ protected:
     QScrollArea             *m_mainScroll;
     ScoreWidget             *m_scoreWidget;
     QPushButton             *m_alignButton;
-    QToolButton             *m_alignerChoice;
+    QPushButton             *m_alignerChoice;
     QWidget                 *m_alignCommands;
     QPushButton             *m_alignAcceptButton;
     QPushButton             *m_alignRejectButton;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -246,6 +246,64 @@ protected:
     bool event(QEvent *) override;
 };
 
+static void
+setupPluginPaths()
+{
+    PluginPathSetter::Paths paths = PluginPathSetter::getDefaultPaths();
+    
+    PluginPathSetter::TypeKey vampPluginTypeKey
+        { KnownPlugins::VampPlugin, KnownPlugins::FormatNative };
+
+    auto defaultVampConfig = paths.at(vampPluginTypeKey);
+
+    for (auto &config : paths) {
+        config.second.directories = {};
+        config.second.useEnvVariable = false;
+    };
+    
+    QStringList bundledPluginPaths =
+        HelperExecPath(HelperExecPath::NativeArchitectureOnly)
+        .getBundledPluginPaths();
+
+    QString alignmentSuffix = "/AudioToScoreAlignment";
+    
+    QStringList vampDirs =
+        defaultVampConfig.directories;
+
+    std::set<QString> vampDirSet;
+    for (auto s : vampDirs) {
+        vampDirSet.insert(s);
+    }
+    
+    QStringList adjustedVampDirs;
+    std::set<QString> alreadySeen;
+
+    for (auto s : vampDirs) {
+        if (alreadySeen.find(s) == alreadySeen.end()) {
+            adjustedVampDirs << s;
+            alreadySeen.insert(s);
+        }
+        if (!s.endsWith(alignmentSuffix)) {
+            QString withSuffix = s + alignmentSuffix;
+            if (vampDirSet.find(withSuffix) == vampDirSet.end()) {
+                adjustedVampDirs << withSuffix;
+            }
+        }
+    }
+    
+    paths[vampPluginTypeKey] = {
+        bundledPluginPaths << adjustedVampDirs,
+        defaultVampConfig.envVariable,
+        true // allow environment variable to override this one
+    };
+    
+    PluginPathSetter::savePathSettings(paths);
+    PluginPathSetter::initialiseEnvironmentVariables();
+
+    TransformFactory::getInstance()->restrictTransformTypes
+        ({ Transform::FeatureExtraction });
+}
+
 int
 main(int argc, char **argv)
 {
@@ -410,59 +468,7 @@ main(int argc, char **argv)
     settings.setValue("rdf-indices", list);
     settings.endGroup();
 
-    PluginPathSetter::Paths paths = PluginPathSetter::getDefaultPaths();
-    
-    PluginPathSetter::TypeKey vampPluginTypeKey
-        { KnownPlugins::VampPlugin, KnownPlugins::FormatNative };
-
-    auto defaultVampConfig = paths.at(vampPluginTypeKey);
-
-    for (auto &config : paths) {
-        config.second.directories = {};
-        config.second.useEnvVariable = false;
-    };
-    
-    QStringList bundledPluginPaths =
-        HelperExecPath(HelperExecPath::NativeArchitectureOnly)
-        .getBundledPluginPaths();
-
-    QString alignmentSuffix = "/AudioToScoreAlignment";
-    
-    QStringList vampDirs =
-        defaultVampConfig.directories;
-
-    std::set<QString> vampDirSet;
-    for (auto s : vampDirs) {
-        vampDirSet.insert(s);
-    }
-    
-    QStringList adjustedVampDirs;
-    std::set<QString> alreadySeen;
-
-    for (auto s : vampDirs) {
-        if (alreadySeen.find(s) == alreadySeen.end()) {
-            adjustedVampDirs << s;
-            alreadySeen.insert(s);
-        }
-        if (!s.endsWith(alignmentSuffix)) {
-            QString withSuffix = s + alignmentSuffix;
-            if (vampDirSet.find(withSuffix) == vampDirSet.end()) {
-                adjustedVampDirs << withSuffix;
-            }
-        }
-    }
-    
-    paths[vampPluginTypeKey] = {
-        bundledPluginPaths << adjustedVampDirs,
-        defaultVampConfig.envVariable,
-        true // allow environment variable to override this one
-    };
-    
-    PluginPathSetter::savePathSettings(paths);
-    PluginPathSetter::initialiseEnvironmentVariables();
-
-    TransformFactory::getInstance()->restrictTransformTypes
-        ({ Transform::FeatureExtraction });
+    setupPluginPaths();
     
     ScoreFinder::initialiseAlignerEnvironmentVariables();
     ScoreFinder::populateUserDirectoriesFromBundled();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -426,15 +426,34 @@ main(int argc, char **argv)
         HelperExecPath(HelperExecPath::NativeArchitectureOnly)
         .getBundledPluginPaths();
 
-    QStringList vampDirectories =
+    QString alignmentSuffix = "/AudioToScoreAlignment";
+    
+    QStringList vampDirs =
         defaultVampConfig.directories;
 
-    for (auto &s : vampDirectories) {
-        s += "/AudioToScoreAlignment";
+    std::set<QString> vampDirSet;
+    for (auto s : vampDirs) {
+        vampDirSet.insert(s);
+    }
+    
+    QStringList adjustedVampDirs;
+    std::set<QString> alreadySeen;
+
+    for (auto s : vampDirs) {
+        if (alreadySeen.find(s) == alreadySeen.end()) {
+            adjustedVampDirs << s;
+            alreadySeen.insert(s);
+        }
+        if (!s.endsWith(alignmentSuffix)) {
+            QString withSuffix = s + alignmentSuffix;
+            if (vampDirSet.find(withSuffix) == vampDirSet.end()) {
+                adjustedVampDirs << withSuffix;
+            }
+        }
     }
     
     paths[vampPluginTypeKey] = {
-        bundledPluginPaths << vampDirectories,
+        bundledPluginPaths << adjustedVampDirs,
         defaultVampConfig.envVariable,
         true // allow environment variable to override this one
     };

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -4,7 +4,7 @@
       "pin": "63e0c3b37b6fb9ce6f074ea8222b4903e4f5568a"
     },
     "svcore": {
-      "pin": "e423b267d1f8be85f03e4335b95e39b0f68dd3d2"
+      "pin": "a173a54cd5e7c61bf71332ebb6ab1417b4319e27"
     },
     "svgui": {
       "pin": "2796d24d9e1918d3ed12057f801ca07c9c1032a3"


### PR DESCRIPTION
* Switch to using a QPushButton for the aligner choice button. This was a far simpler change than I'd expected - I hadn't expected it to support merely attaching a menu in the same way as the tool button, but it does!

* Look in the normal Vamp plugin paths as well as the `AudioToScoreAlignment` subdirs.

