### PR TITLE
Sync up with SV v5.2 code

### DIFF
--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -33,7 +33,7 @@
 
 #include "vrvtrim.h"
 
-#define DEBUG_SCORE_WIDGET 1
+//#define DEBUG_SCORE_WIDGET 1
 //#define DEBUG_EVENT_FINDING 1
 
 static QColor navigateHighlightColour("#59c4df");
@@ -372,8 +372,10 @@ ScoreWidget::setMusicalEvents(const Score::MusicalEventList &events)
 {
     m_musicalEvents = events;
 
+#ifdef DEBUG_SCORE_WIDGET
     SVDEBUG << "ScoreWidget::setMusicalEvents: " << events.size()
             << " events" << endl;
+#endif
 
     m_idDataMap.clear();
     m_labelIdMap.clear();
@@ -432,7 +434,9 @@ ScoreWidget::setMusicalEvents(const Score::MusicalEventList &events)
         ++ix;
     }
 
+#ifdef DEBUG_SCORE_WIDGET
     SVDEBUG << "ScoreWidget::setMusicalEvents: Done" << endl;
+#endif
 }
 
 void
@@ -467,8 +471,10 @@ ScoreWidget::mouseMoveEvent(QMouseEvent *e)
 
     m_eventUnderMouse = getEventAtPoint(e->pos());
 
+#ifdef DEBUG_SCORE_WIDGET
     SVDEBUG << "ScoreWidget::mouseMoveEvent: id under mouse = "
             << m_eventUnderMouse.id << endl;
+#endif
     
     update();
 
@@ -766,8 +772,10 @@ ScoreWidget::paintEvent(QPaintEvent *e)
     double ww = widgetSize.width(), wh = widgetSize.height();
     double pw = pageSize.width(), ph = pageSize.height();
 
+#ifdef DEBUG_SCORE_WIDGET
     SVDEBUG << "ScoreWidget::paint: widget size " << ww << "x" << wh
             << ", page size " << pw << "x" << ph << endl;
+#endif
     
     if (!ww || !wh || !pw || !ph) {
         SVDEBUG << "ScoreWidgetPDF::paint: one of our dimensions is zero, can't proceed" << endl;
@@ -795,12 +803,16 @@ ScoreWidget::paintEvent(QPaintEvent *e)
 
         if (m_mouseActive) {
             event = m_eventUnderMouse;
+#ifdef DEBUG_SCORE_WIDGET
             SVDEBUG << "ScoreWidget::paint: under mouse = "
                     << event.label << endl;
+#endif
         } else {
             event = m_eventToHighlight;
+#ifdef DEBUG_SCORE_WIDGET
             SVDEBUG << "ScoreWidget::paint: to highlight = "
                     << event.label << endl;
+#endif
         }
 
         if (!event.isNull()) {
@@ -872,6 +884,7 @@ ScoreWidget::paintEvent(QPaintEvent *e)
                              m_selectEnd.location, inclusiveComparator);
         }
 
+#ifdef DEBUG_SCORE_WIDGET
         SVDEBUG << "ScoreWidget::paint: selection spans from "
                 << m_selectStart.location << " to " << m_selectEnd.location
                 << " giving us iterators at "
@@ -883,6 +896,7 @@ ScoreWidget::paintEvent(QPaintEvent *e)
                     i1->notes.empty() ? "(location without note)" :
                     i1->notes[0].noteId)
                 << endl;
+#endif
 
         double lineOrigin = m_pageToWidget.map(QPointF(0, 0)).x();
         double lineWidth = m_pageToWidget.map(QPointF(pageSize.width(), 0)).x();
@@ -985,8 +999,10 @@ ScoreWidget::setHighlightEventByLabel(EventLabel label)
 
     m_highlightEventLabel = label;
     
+#ifdef DEBUG_SCORE_WIDGET
     SVDEBUG << "ScoreWidget::setHighlightEventByLabel: Event with label \""
             << label << "\" found at " << m_eventToHighlight.location << endl;
+#endif
     
     int page = m_eventToHighlight.page;
     if (page != m_page) {

--- a/main/ScoreWidget.cpp
+++ b/main/ScoreWidget.cpp
@@ -240,7 +240,7 @@ ScoreWidget::findSystemExtents(QByteArray svgData, shared_ptr<QSvgRenderer> rend
     // still don't think it's a significant overhead
     
     QDomDocument doc;
-    doc.setContent(svgData, false);
+    doc.setContent(svgData);
 
     Extent currentExtent;
     vector<double> staffLines;

--- a/main/segfault.c
+++ b/main/segfault.c
@@ -1,0 +1,228 @@
+// Modified version of BSD libsegfault
+
+/*
+ * Copyright (C) 2015 Stanislav Sedov <stas@FreeBSD.org>
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+
+#include <err.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ucontext.h>
+#include <unistd.h>
+
+#define UNW_LOCAL_ONLY 1
+
+#include <unwind.h>
+#include <libunwind.h>
+
+#define	BACKTRACE_DEPTH	256
+#define	NULLSTR	"(null)"
+
+static inline void
+print_str(int fd, const char *str)
+{
+
+	if (str == NULL) {
+		write(fd, NULLSTR, strlen(NULLSTR));
+	} else {
+		write(fd, str, strlen(str));
+	}
+}
+
+static void
+print_unw_error(const char *fun, int error)
+{
+
+	print_str(STDERR_FILENO, fun);
+	print_str(STDERR_FILENO, ": ");
+	print_str(STDERR_FILENO, unw_strerror(error));
+	print_str(STDERR_FILENO, "\n");
+}
+
+static int
+print_stack_trace(ucontext_t *context)
+{
+	unw_cursor_t cursor;
+	unw_word_t backtrace[BACKTRACE_DEPTH];
+	unw_word_t ip, off;
+	char buf[1024];
+	unsigned int i, level;
+	int ret;
+
+	if ((ret = unw_init_local(&cursor, context)) != 0) {
+		print_unw_error("unw_init_local", ret);
+		return (1);
+	}
+
+	print_str(STDERR_FILENO, "   thread frame     IP       function\n");
+	level = 0;
+	ret = 0;
+	for (;;) {
+		char name[128];
+
+		if (level >= BACKTRACE_DEPTH)
+			break;
+		unw_get_reg(&cursor, UNW_REG_IP, &ip);
+		backtrace[level] = ip;
+
+		/*
+		 * Print the function name and offset.
+		 */
+		ret = unw_get_proc_name(&cursor, name, sizeof(name), &off);
+		if (ret == 0) {
+			snprintf(buf, sizeof(buf),
+			    "  [-] %2d: 0x%09" PRIxPTR
+			    ": %s()+0x%lx\n",
+			    level, ip, name,
+			    (uintptr_t)off);
+		} else {
+			snprintf(buf, sizeof(buf),
+			    "  [-] %2d: 0x%09" PRIxPTR
+			    ": <unknown>\n",
+			    level, ip);
+		}
+		print_str(STDERR_FILENO, buf);
+		level++;
+		ret = unw_step(&cursor);
+		if (ret <= 0)
+			break;
+	}
+	if (ret < 0) {
+		print_unw_error("unw_step_ptr", ret);
+		return (1);
+	}
+	print_str(STDERR_FILENO, "\nBacktrace:");
+	for (i = 0; i < level; i++) {
+		snprintf(buf, sizeof(buf), " 0x%"PRIxPTR, backtrace[i]);
+		print_str(STDERR_FILENO, buf);
+	}
+	print_str(STDERR_FILENO, "\n");
+	return (0);
+}
+
+static void
+segfault_handler(int sig, siginfo_t * /* info */, void *ctx)
+{
+	struct sigaction sa;
+	ucontext_t *uap = ctx;
+	char buf[16];
+
+	print_str(STDERR_FILENO, "Caught signal ");
+	snprintf(buf, sizeof(buf), "%d (", sig);
+	print_str(STDERR_FILENO, buf);
+	print_str(STDERR_FILENO, strsignal(sig));
+	print_str(STDERR_FILENO, ") in pid");
+	snprintf(buf, sizeof(buf), " [%d]\n", getpid());
+	print_str(STDERR_FILENO, buf);
+	print_str(STDERR_FILENO, "\n");
+
+	print_stack_trace(uap);
+
+	/*
+	 * Restore the original signal handler and propagate the signal.
+	 */
+	sigemptyset (&sa.sa_mask);
+	sa.sa_handler = SIG_DFL;
+	sa.sa_flags = 0;
+	sigaction(sig, &sa, NULL);
+	kill(getpid(), sig);
+}
+
+static int
+signal_num(const char *sig)
+{
+	unsigned int i;
+
+	for (i = 0; i < NSIG; i++) {
+		if (strcasecmp(strsignal(i), sig) == 0)
+			return (i);
+	}
+	return (0);
+}
+
+static int
+install_signal_str(const char *signals0, struct sigaction *sa)
+{
+	char *signals, *sig, *p;
+
+	signals = strdup(signals0);
+	if (signals == NULL) {
+		warn("strdup()");
+		return (1);
+	}
+	p = signals;
+	while ((sig = strsep(&p, " \t")) != NULL) {
+		int signum;
+
+		/* Skip whitespace. */
+		if (*sig == '\0' || *sig == ' ' || *sig == '\t')
+			continue;
+		signum = signal_num(sig);
+		if (signum == 0) {
+			warnx("Unknown signal '%s', ignoring", sig);
+			continue;
+		}
+		sigaction(signum, sa, NULL);
+	}
+	free(signals);
+	return (0);
+}
+
+static int
+__attribute__((constructor))
+segfault_init(void)
+{
+	struct sigaction sa;
+	const char *signals;
+	int error;
+
+	sigemptyset(&sa.sa_mask);
+	sa.sa_sigaction = &segfault_handler;
+	sa.sa_flags = SA_RESTART | SA_SIGINFO | SA_ONSTACK;
+
+	/*
+	 * Configure the signal handlers.
+	 */
+	signals = getenv("SEGFAULT_SIGNALS");
+	error = 0;
+	if (signals == NULL) {
+		sigaction(SIGSEGV, &sa, NULL);
+	} else if (strcasecmp(signals, "all") == 0) {
+		sigaction(SIGSEGV, &sa, NULL);
+		sigaction(SIGBUS, &sa, NULL);
+		sigaction(SIGILL, &sa, NULL);
+		sigaction(SIGABRT, &sa, NULL);
+		sigaction(SIGFPE, &sa, NULL);
+		sigaction(SIGSYS, &sa, NULL);
+	} else if (*signals != '\0') {
+		error = install_signal_str(signals, &sa);
+	}
+
+	return (error);
+}

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,9 @@ dl_dep = meson.get_compiler('c').find_library('dl', required: false)
 vampsdk_dep = dependency('vamp-sdk', version: '>= 2.10', required: false)
 vamphostsdk_dep = dependency('vamp-hostsdk', version: '>= 2.10', required: false)
 
+unwind_dep = []
+with_unwind = false
+
 if system == 'linux'
 
   capnp = find_program('capnp')
@@ -117,6 +120,8 @@ if system == 'linux'
   alsa_dep = dependency('alsa')
   
   portaudio_dep = dependency('portaudio-2.0', version: '>= 19', required: false)
+
+  unwind_dep = dependency('libunwind', required: false)
 
   feature_dependencies = [
     vamphostsdk_dep,
@@ -172,6 +177,15 @@ if system == 'linux'
     '-D__LINUX_ALSASEQ__',
     '-D__LINUX_ALSA__' # for RtMidi
   ]
+
+  if unwind_dep.found() and buildtype.startswith('debug')
+    with_unwind = true
+    feature_defines += [
+      '-DHAVE_UNWIND',
+    ]
+  else
+    unwind_dep = []
+  endif
 
   if portaudio_dep.found()
     feature_defines += [
@@ -1094,6 +1108,12 @@ pp_main_files = [
   'piano-precision-aligner/Score.cpp',
 ]
 
+  if with_unwind
+    pp_main_files += [
+      'main/segfault.c',
+    ]
+  endif
+
 verovio_files = [
   'verovio/src/abbr.cpp',
   'verovio/src/accid.cpp',
@@ -1577,7 +1597,8 @@ executable(
     qt_dep,
     feature_dependencies,
     os_dep,
-    dl_dep
+    dl_dep,
+    unwind_dep,
   ],
   cpp_args: [
     feature_defines,

--- a/repoint-lock.json
+++ b/repoint-lock.json
@@ -4,31 +4,31 @@
       "pin": "63e0c3b37b6fb9ce6f074ea8222b4903e4f5568a"
     },
     "svcore": {
-      "pin": "9a6763ad2867f9f72ed0a86a3458b3cb1bc10a87"
+      "pin": "83195a39dfe87b603424f38646033222d46e8362"
     },
     "svgui": {
-      "pin": "2796d24d9e1918d3ed12057f801ca07c9c1032a3"
+      "pin": "843bb82108563044627d5af24b83778e82faebc1"
     },
     "svapp": {
-      "pin": "f51a1690f3f92e2421916d39a3385d49214e60c6"
+      "pin": "a26bcdad73f61168a832867ed58cb0037ec29280"
     },
     "checker": {
-      "pin": "fae540cf4a79ac5ed5a4d4dc0df680b1acbe8628"
+      "pin": "5ba274674cf9cbe1eafa2243e1356b2076c3dbd7"
     },
     "sv-dependency-builds": {
       "pin": "01bb14514cdbed5f7741ddad8d0a0e1021fbbcbc"
     },
     "icons/scalable": {
-      "pin": "fa47556361a34604e042c9a1820051424451a024"
+      "pin": "40ecb261e124cad07bf7adc85b48088bf366d9fa"
     },
     "piper": {
       "pin": "3a742c556ac1f2bf9823f30b937c71c690e1f6ae"
     },
     "piper-vamp-cpp": {
-      "pin": "c6519fcb8c926c8331f5e6deb351d738da48600a"
+      "pin": "6f16a09b78b995b3cf2844f00033bde90e5e0936"
     },
     "dataquay": {
-      "pin": "79623fb778da"
+      "pin": "3dbf25604e7a"
     },
     "verovio": {
       "pin": "c482e357cfbe42c76f41a37485740f66bcb39637"
@@ -43,19 +43,19 @@
       "pin": "38c3e524416a"
     },
     "bqaudioio": {
-      "pin": "88520ab5b8e5"
+      "pin": "017ab3ed3a33"
     },
     "bqaudiostream": {
-      "pin": "5d5950bc4d93"
+      "pin": "495b3242c489"
     },
     "bqthingfactory": {
       "pin": "2e4bd170f57f"
     },
     "piano-precision-aligner": {
-      "pin": "ea967162dcc582a8354d4b8a6ae3b3a2a914589d"
+      "pin": "3b1500314e36aa73bc37587bcfee056c799794cb"
     },
     "dummy-score-aligner": {
-      "pin": "0d39744a7a7e63471e0219e8287d5c1a564de7f5"
+      "pin": "489aba2ef9411dea17eb407aa7332ddc8152f960"
     }
   }
 }


### PR DESCRIPTION
This is a routine update to sync up with the forthcoming SV v5.2. (Remember to run `./repoint update`.)

The most noticeable change *should* be that manipulating the views (scroll, zoom etc) is just generally a bit more responsive.

If you're wondering about the new file in the top-level directory, it's a useful reporting tool during development which adds a backtrace facility on Linux when a segfault happens (with similar purpose to the familiar program crash dialog on the Mac).
